### PR TITLE
Press8-25: Prevent partner activation redirection

### DIFF
--- a/includes/Partners.php
+++ b/includes/Partners.php
@@ -10,6 +10,7 @@ namespace NewfoldLabs\WP\Module\Activation;
 use NewfoldLabs\WP\Module\Activation\Partners\Akismet;
 use NewfoldLabs\WP\ModuleLoader\Container;
 use NewfoldLabs\WP\Module\Activation\Partners\CreativeMail;
+use NewfoldLabs\WP\Module\Activation\Partners\Jetpack;
 use NewfoldLabs\WP\Module\Activation\Partners\MonsterInsights;
 use NewfoldLabs\WP\Module\Activation\Partners\OptinMonster;
 use NewfoldLabs\WP\Module\Activation\Partners\WpForms;
@@ -44,6 +45,7 @@ class Partners {
 
 		$akismet          = new Akismet();
 		$creative_mail    = new CreativeMail();
+		$jetpack          = new Jetpack();
 		$monster_insights = new MonsterInsights();
 		$optin_monster    = new OptinMonster();
 		$wp_forms         = new WpForms();
@@ -51,6 +53,7 @@ class Partners {
 
 		$akismet->init();
 		$creative_mail->init();
+		$jetpack->init();
 		$monster_insights->init();
 		$optin_monster->init();
 		$wp_forms->init();

--- a/includes/Partners/Jetpack.php
+++ b/includes/Partners/Jetpack.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Jetpack.
+ *
+ * @package NewfoldLabs\WP\Module\Activation
+ */
+
+namespace NewfoldLabs\WP\Module\Activation\Partners;
+
+/**
+ * Jetpack class.
+ */
+class Jetpack extends Partner {
+
+	/**
+	 * Initialize.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_action( 'admin_init', array( $this, 'disable_redirect' ), 5 ); // Priority 5 to run before Jetpack's own hook.
+	}
+
+	/**
+	 * Disable plugin activation redirect.
+	 *
+	 * @return void
+	 */
+	public function disable_redirect() {
+		if ( get_transient( 'activated_jetpack' ) ) {
+			delete_transient( 'activated_jetpack' );
+		}
+	}
+}


### PR DESCRIPTION
## Proposed changes
Fixes an issue where Jetpack activation is hijacking onboarding DIY flow.

https://jira.newfold.com/browse/PRESS8-25

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
