### PR TITLE
Do not check `isFreshInstallation` until `plugins_loaded`

### DIFF
--- a/includes/Partners.php
+++ b/includes/Partners.php
@@ -36,12 +36,14 @@ class Partners {
 	public function __construct( Container $container ) {
 		$this->container = $container;
 
-		$is_fresh_install = $container->has( 'isFreshInstallation' ) ? $container->get( 'isFreshInstallation' ) : false;
-		if ( $is_fresh_install ) {
-			update_option( 'nfd_module_activation_fresh_install', true );
-		} else {
-			update_option( 'nfd_module_activation_fresh_install', false );
-		}
+		add_action( 'plugins_loaded', function() use ( $container ) {
+			$is_fresh_install = $container->has( 'isFreshInstallation' ) ? $container->get( 'isFreshInstallation' ) : false;
+			if ( $is_fresh_install ) {
+				update_option( 'nfd_module_activation_fresh_install', true );
+			} else {
+				update_option( 'nfd_module_activation_fresh_install', false );
+			}
+		});
 
 		$akismet          = new Akismet();
 		$creative_mail    = new CreativeMail();

--- a/includes/Partners.php
+++ b/includes/Partners.php
@@ -36,14 +36,17 @@ class Partners {
 	public function __construct( Container $container ) {
 		$this->container = $container;
 
-		add_action( 'plugins_loaded', function() use ( $container ) {
-			$is_fresh_install = $container->has( 'isFreshInstallation' ) ? $container->get( 'isFreshInstallation' ) : false;
-			if ( $is_fresh_install ) {
-				update_option( 'nfd_module_activation_fresh_install', true );
-			} else {
-				update_option( 'nfd_module_activation_fresh_install', false );
+		add_action(
+			'plugins_loaded',
+			function () use ( $container ) {
+				$is_fresh_install = $container->has( 'isFreshInstallation' ) ? $container->get( 'isFreshInstallation' ) : false;
+				if ( $is_fresh_install ) {
+					update_option( 'nfd_module_activation_fresh_install', true );
+				} else {
+					update_option( 'nfd_module_activation_fresh_install', false );
+				}
 			}
-		});
+		);
 
 		$akismet          = new Akismet();
 		$creative_mail    = new CreativeMail();


### PR DESCRIPTION
## Proposed changes

Replacing: https://github.com/newfold-labs/wp-module-install-checker/pull/4

Fixes: https://github.com/newfold-labs/wp-module-activation/issues/4, https://github.com/newfold-labs/wp-module-install-checker/issues/2

I see the following warning after activating.

> Notice: Function WP_User_Query::query was called incorrectly. User queries should not be run before the plugins_loaded hook. Please see [Debugging in WordPress](https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/) for more information. (This message was added in version 6.1.1.) in /var/www/html/wp-includes/functions.php on line 6085 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-includes/functions.php:6085) in /var/www/html/wp-admin/includes/misc.php on line 1438 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-includes/functions.php:6085) in /var/www/html/wp-includes/functions.php on line 7108 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-includes/functions.php:6085) in /var/www/html/wp-admin/admin-header.php on line 9 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-includes/functions.php:6085) in /var/www/html/wp-includes/option.php on line 1692 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-includes/functions.php:6085) in /var/www/html/wp-includes/option.php on line 1693

Due to [InstallChecker::isFreshInstallation()](https://github.com/newfold-labs/wp-module-install-checker/blob/9d43e916b8c4e752b45c868b41340b84bcb686a6/includes/InstallChecker.php#L13) calling [::getOldestUser()](https://github.com/newfold-labs/wp-module-install-checker/blob/9d43e916b8c4e752b45c868b41340b84bcb686a6/includes/InstallChecker.php#L59) which uses `WP_User_Query`.

https://github.com/WordPress/WordPress/blob/6.6.2/wp-includes/class-wp-user-query.php#L785-L795

This fix wraps

https://github.com/newfold-labs/wp-module-activation/blob/6004a69982fd788f2781bcf6b35ee29394d477b5/includes/Partners.php#L39-L44

in a function which runs on the `plugins_loaded` action.
 
The subsequent `->init()` calls do not depend on this value being set.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
