### PR TITLE
Add initial docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,4 +37,4 @@ composer run test
 
 ## Keeping documentation current
 
-When you change code, features, or workflows, update the docs. When cutting a release, update **docs/changelog.md**.
+When you change code, features, or workflows, update the docs. Keep **docs/index.md** current: when you add, remove, or rename doc files, update the table of contents (and quick links if present). When cutting a release, update **docs/changelog.md**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent guidance – wp-module-activation
+
+This file gives AI agents a quick orientation to the repo. For full detail, see the **docs/** directory.
+
+## What this project is
+
+- **wp-module-activation** – Handles WordPress brand plugin activation logic. Hooks into `newfold_container_set` and instantiates `Activation`, which wires up `Partners` (Akismet, CreativeMail, Jetpack, MonsterInsights, OptinMonster, WpForms, Yoast, WordPress) for partner integrations and fresh-install detection. Maintained by Newfold Labs.
+
+- **Stack:** PHP 7.3+. No production Composer dependencies; expects the loader and container to be set by the host.
+
+- **Architecture:** On `newfold_container_set`, creates `new Activation( $container )`, which creates `new Partners( $container )`. Each partner’s `init()` runs; Partners also adds a `plugins_loaded` filter for fresh install handling.
+
+## Key paths
+
+| Purpose | Location |
+|---------|----------|
+| Bootstrap | `bootstrap.php` – hooks `newfold_container_set` |
+| Activation | `includes/Activation.php` |
+| Partners | `includes/Partners.php` – partner integrations (Akismet, Jetpack, etc.) |
+| Tests | `tests/` (Codeception wpunit) |
+
+## Essential commands
+
+```bash
+composer install
+composer run lint
+composer run fix
+composer run test
+```
+
+## Documentation
+
+- **Full documentation** is in **docs/**. Start with **docs/index.md**.
+- **CLAUDE.md** is a symlink to this file (AGENTS.md).
+
+---
+
+## Keeping documentation current
+
+When you change code, features, or workflows, update the docs. When cutting a release, update **docs/changelog.md**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,15 @@
+# Development
+
+## Linting
+
+- **PHP:** `composer run lint`, `composer run fix`. Uses `phpcs.xml` and `newfold-labs/wp-php-standards`.
+
+## Testing
+
+- **Codeception wpunit:** `composer run test`, `composer run test-coverage`. Open `tests/_output/html/index.html` for coverage.
+
+## Workflow
+
+1. Make changes in `includes/` or `bootstrap.php`.
+2. Run `composer run lint` and `composer run test` before committing.
+3. When adding or changing partners or hooks, update [integration.md](integration.md) and [overview.md](overview.md). When cutting a release, update **docs/changelog.md**.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-activation
+title: Development
+description: Lint, test, and workflow.
+updated: 2025-03-18
+---
+
 # Development
 
 ## Linting

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,36 @@
+# Getting started
+
+## Prerequisites
+
+- **PHP** 7.3+.
+- **Composer** and **WordPress** (for running the module and tests).
+
+## Install
+
+```bash
+composer install
+```
+
+No production dependencies; dev deps include WordPress, Codeception, PHPCS.
+
+## Run tests
+
+```bash
+composer run test
+composer run test-coverage   # then open tests/_output/html/index.html
+```
+
+## Lint
+
+```bash
+composer run lint
+composer run fix
+```
+
+## Using in a host plugin
+
+1. Depend on `newfold-labs/wp-module-activation` via Composer.
+2. Ensure the module’s `bootstrap.php` is loaded (via Composer autoload `files`) before or when the container is set.
+3. When the host calls `container( $container )`, the action `newfold_container_set` runs and this module’s `Activation` and `Partners` run. No further configuration required.
+
+See [integration.md](integration.md) for details.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-activation
+title: Getting started
+description: Prerequisites, install, and run.
+updated: 2025-03-18
+---
+
 # Getting started
 
 ## Prerequisites

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,19 @@
+# wp-module-activation – Documentation index
+
+Documentation for wp-module-activation, for **humans** and **AI agents**. Start here.
+
+## Table of contents
+
+| Document | Description |
+|----------|-------------|
+| [overview.md](overview.md) | What the module does and who maintains it. |
+| [getting-started.md](getting-started.md) | Prerequisites, install, and tests. |
+| [integration.md](integration.md) | How the module hooks into the container and what partners do. |
+| [development.md](development.md) | Lint, test, and workflow. |
+
+## Quick links
+
+- **New to the repo:** [overview.md](overview.md) then [getting-started.md](getting-started.md).
+- **Integrating in a host plugin:** [integration.md](integration.md).
+
+Root **AGENTS.md** gives a short agent summary and points here.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-activation
+title: Documentation index
+description: Table of contents and quick links.
+updated: 2025-03-18
+---
+
 # wp-module-activation – Documentation index
 
 Documentation for wp-module-activation, for **humans** and **AI agents**. Start here.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-activation
+title: Integration
+description: How the module registers and integrates.
+updated: 2025-03-18
+---
+
 # Integration
 
 ## How the module runs

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,22 @@
+# Integration
+
+## How the module runs
+
+The module does not register with the Newfold Module Loader as a toggleable module. It hooks into **`newfold_container_set`** (in `bootstrap.php`). When the host (or loader) sets the container, the callback runs:
+
+```php
+new Activation( $container );
+```
+
+`Activation` receives the container and instantiates `Partners( $container )`. So the host only needs to:
+
+1. Include the package (Composer).
+2. Set the container via `NewfoldLabs\WP\ModuleLoader\container( $container )` as usual. This module will run when that happens.
+
+## Partners
+
+The `Partners` class creates one instance of each partner integration (Akismet, CreativeMail, Jetpack, MonsterInsights, OptinMonster, WpForms, Yoast, WordPress) and calls `init()` on each. Those classes typically add activation hooks or filters for their respective plugins. See `includes/Partners/` for per-partner logic.
+
+## Fresh install
+
+`Partners` adds a filter on `plugins_loaded` (`is_fresh_install`) to detect fresh installs and run any one-time activation logic. The container is used to get the plugin file/basename for context.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-activation
+title: Overview
+description: What the module does and who maintains it.
+updated: 2025-03-18
+---
+
 # Overview
 
 ## What the module does

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,15 @@
+# Overview
+
+## What the module does
+
+**wp-module-activation** handles activation-related logic for Newfold WordPress brand plugins. When the host sets the container (`newfold_container_set`), this module runs and:
+
+- **Activation** – Instantiates an `Activation` class that receives the container.
+- **Partners** – Instantiates `Partners`, which initializes partner integrations (Akismet, CreativeMail, Jetpack, MonsterInsights, OptinMonster, WpForms, Yoast, WordPress). Each partner’s `init()` runs to register activation or post-activation behavior.
+- **Fresh install** – A `plugins_loaded` filter is used to detect fresh installs and run any one-time logic.
+
+The module does not register itself with the loader as a toggleable module; it runs when the container is set, so the host must include it as a Composer dependency and load it (e.g. via autoload) before or when the container is set.
+
+## Who maintains it
+
+- **Newfold Labs** (Newfold Digital). Distributed via Newfold Satis.


### PR DESCRIPTION
Adds AGENTS.md, CLAUDE.md (symlink to AGENTS.md), and docs/ per the Newfold modules documentation rollout: overview, getting-started, integration, development, and dependencies where applicable.

Made with [Cursor](https://cursor.com)