### PR TITLE
Fix: undefined index wpseo_premium when free is installed

### DIFF
--- a/includes/Partners/Yoast.php
+++ b/includes/Partners/Yoast.php
@@ -64,11 +64,13 @@ class Yoast extends Partner {
 	 * @return void
 	 */
 	public function disable_onboarding_redirect() {
-		if ( class_exists( 'WPSEO_Options' ) ) {
-			// Disable redirect to Yoast onboarding (free version).
-			\WPSEO_Options::set( 'should_redirect_after_install_free', false );
-
-			// Disable redirect to Yoast onboarding (premium version).
+		if ( ! class_exists( 'WPSEO_Options' ) ) {
+			return;
+		}
+		// Disabilita redirect onboarding (versione free).
+		\WPSEO_Options::set( 'should_redirect_after_install_free', false );
+		// Solo se Yoast Premium è attivo.
+		if ( defined( 'WPSEO_PREMIUM_FILE' ) ) {
 			\WPSEO_Options::set( 'should_redirect_after_install', false, 'wpseo_premium' );
 		}
 	}


### PR DESCRIPTION
## Proposed changes

Fixes a PHP error on sites running Yoast SEO (free) without Yoast SEO Premium installed.

In disable_onboarding_redirect(), we unconditionally call:

\WPSEO_Options::set( 'should_redirect_after_install', false, 'wpseo_premium' );
The wpseo_premium option group is only registered in WPSEO_Options::$options when Yoast SEO Premium is active. On free-only installs, Yoast throws:

Undefined index: wpseo_premium
in wordpress-seo/inc/options/class-wpseo-options.php (~line 578), inside get_lookup_table().

This is triggered during admin_init / admin-ajax.php by NewfoldLabs\WP\Module\Activation\Partners\Yoast::disable_onboarding_redirect.

Fix: wrap the premium-specific WPSEO_Options::set() call in a defined( 'WPSEO_PREMIUM_FILE' ) check, matching how Yoast detects an active Premium installation. The free-version call (should_redirect_after_install_free) is unchanged.

Related Yoast community PR (workaround on their side): https://github.com/Yoast/wordpress-seo/pull/22791

The bug has been replicated here, in combination with Oxygen builder:
https://newfold.atlassian.net/browse/DEVSUP-145520

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->