### PR TITLE
Opt out of WP Forms Setup Wizard during onboarding

### DIFF
--- a/includes/Partners/WpForms.php
+++ b/includes/Partners/WpForms.php
@@ -19,6 +19,17 @@ class WpForms extends Partner {
 	 */
 	public function init() {
 		$this->disable_redirect();
+
+		/**
+		 * Filter: 'wpforms_setup_wizard_setup_wizard_is_disabled' - Opts out of the WP Forms Setup Wizard.
+		 *
+		 * Returning true opts out of the first-run wizard so that new sites use our
+		 * onboarding experience. The wizard remains available to the user on demand
+		 * from the WP Forms Welcome page once onboarding is complete.
+		 *
+		 * @param bool $disabled Whether the wizard is disabled. Default false.
+		 */
+		add_filter( 'wpforms_setup_wizard_setup_wizard_is_disabled', '__return_true' );
 	}
 
 	/**

--- a/tests/wpunit/WpFormsWPUnitTest.php
+++ b/tests/wpunit/WpFormsWPUnitTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace NewfoldLabs\WP\Module\Activation;
+
+use NewfoldLabs\WP\Module\Activation\Partners\WpForms;
+
+/**
+ * WP Forms partner wpunit tests.
+ *
+ * @coversDefaultClass \NewfoldLabs\WP\Module\Activation\Partners\WpForms
+ */
+class WpFormsWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCase {
+
+	/**
+	 * Tear down after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		remove_filter( 'wpforms_setup_wizard_setup_wizard_is_disabled', '__return_true' );
+		delete_option( 'wpforms_activation_redirect' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Init opts out of the Setup Wizard so our onboarding experience is used.
+	 *
+	 * @return void
+	 */
+	public function test_init_disables_setup_wizard() {
+		$wp_forms = new WpForms();
+		$wp_forms->init();
+
+		$this->assertTrue(
+			(bool) apply_filters( 'wpforms_setup_wizard_setup_wizard_is_disabled', false )
+		);
+	}
+
+	/**
+	 * Init still disables the legacy activation redirect.
+	 *
+	 * @return void
+	 */
+	public function test_init_disables_activation_redirect() {
+		delete_option( 'wpforms_activation_redirect' );
+
+		$wp_forms = new WpForms();
+		$wp_forms->init();
+
+		$this->assertTrue( get_option( 'wpforms_activation_redirect' ) );
+	}
+}


### PR DESCRIPTION
https://newfold.atlassian.net/browse/PRESS0-4849

## Proposed changes

WP Forms 2.0.0.2 introduces a Setup Wizard that can launch on the first admin pageview after activation. This opts out of it so that new sites use our onboarding experience, consistent with how this module already handles other partner plugins.

This uses the supported `wpforms_setup_wizard_setup_wizard_is_disabled` filter, registered in the partner's `init()`. The wizard remains available to the user on demand from the WP Forms Welcome page once onboarding is complete.

The existing `disable_redirect()` is unchanged — it covers the separate legacy activation redirect path.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Visual

n/a — no UI surface in this module.

## Checklist

- [x] Verified against WP Forms 2.0.0.2 in `wp-env`: `SetupWizard::is_disabled()` returns `false` before `WpForms::init()` and `true` after.
- [x] Confirmed `disable_redirect()` still sets the `wpforms_activation_redirect` option.
- [x] `composer run test` passes (11 tests).
- [x] `composer run lint` passes on the changed files.
- [x] New test fails without the change and passes with it.

## Further comments

Per WP Forms' own documentation, this filter covers launches driven by an admin pageview. For provisioning flows that install and activate in a single request, they also expose a persisted `wpforms_setup_wizard_disabled` option and a `WPFORMS_SETUP_WIZARD_DISABLED` constant, which are read by the same `is_disabled()` check. Worth considering separately if we want a switch that does not depend on plugin load order.
